### PR TITLE
doing order cancellation via a string of orderid instead of using an Order object

### DIFF
--- a/apps/OrderProcessor/src/main/java/orderProcessor/OrderProcessor.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/OrderProcessor.java
@@ -3,8 +3,6 @@ package orderProcessor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.UUID;
 
 public class OrderProcessor {
 
@@ -37,24 +35,9 @@ public class OrderProcessor {
 
   public Boolean cancelOrder(String orderId, String orderTicker, String orderType) {
     
-    try {
       TradeBook book = orderProcessor.getTradeBook(Ticker.valueOf(orderTicker));
-      PriorityQueue<Order> orderQueue;
-
-      if (OrderType.valueOf(orderType) == OrderType.BUY) {
-        orderQueue = book.getBuyOrders();
-      } else {
-        orderQueue = book.getSellOrders();
-      }
-      
-      return orderQueue.remove(order);
-    } catch (Exception e) {
-      // TODO: handle exception
-    }
-    
+      return book.removeOrder(orderId, orderType);
   }
-
-  private Ticker getTickerFromString()
 
   public void resetInstance() {
     orderProcessor = null;

--- a/apps/OrderProcessor/src/main/java/orderProcessor/OrderProcessor.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/OrderProcessor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.UUID;
 
 public class OrderProcessor {
 
@@ -34,18 +35,26 @@ public class OrderProcessor {
     return tradeBookMap.get(ticker);
   }
 
-  public Boolean cancelOrder(Order order) {
-    TradeBook book = orderProcessor.getTradeBook(order.getTicker());
-    PriorityQueue<Order> orderQueue;
+  public Boolean cancelOrder(String orderId, String orderTicker, String orderType) {
+    
+    try {
+      TradeBook book = orderProcessor.getTradeBook(Ticker.valueOf(orderTicker));
+      PriorityQueue<Order> orderQueue;
 
-    if (order.getType() == OrderType.BUY) {
-      orderQueue = book.getBuyOrders();
-    } else {
-      orderQueue = book.getSellOrders();
+      if (OrderType.valueOf(orderType) == OrderType.BUY) {
+        orderQueue = book.getBuyOrders();
+      } else {
+        orderQueue = book.getSellOrders();
+      }
+      
+      return orderQueue.remove(order);
+    } catch (Exception e) {
+      // TODO: handle exception
     }
-
-    return orderQueue.remove(order);
+    
   }
+
+  private Ticker getTickerFromString()
 
   public void resetInstance() {
     orderProcessor = null;

--- a/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
@@ -29,12 +29,10 @@ public class TradeBook {
   public Boolean removeOrder(String orderId, String orderType){
 
     PriorityQueue<Order> targetQueue = (OrderType.valueOf(orderType) == OrderType.BUY) ? buyOrders : sellOrders;
-    Order orderToRemove=null;
 
     for (Order order : targetQueue){
       if (order.getId().toString().equals(orderId)){
-        orderToRemove = order;
-        return targetQueue.remove(orderToRemove);
+        return targetQueue.remove(order);
       }
     }
 

--- a/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
@@ -25,4 +25,8 @@ public class TradeBook {
   public PriorityQueue<Order> getSellOrders() {
     return sellOrders;
   }
+
+  public Order getOrderById(String uuid, String type){
+    if (type)
+  }
 }

--- a/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
@@ -34,15 +34,11 @@ public class TradeBook {
     for (Order order : targetQueue){
       if (order.getId().toString().equals(orderId)){
         orderToRemove = order;
-        break;
+        return targetQueue.remove(orderToRemove);
       }
     }
 
-    if (orderToRemove == null){
-      return false;
-    } else {
-      return targetQueue.remove(orderToRemove);
-    }
+    return false;
       
   }
     

--- a/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
+++ b/apps/OrderProcessor/src/main/java/orderProcessor/TradeBook.java
@@ -26,7 +26,24 @@ public class TradeBook {
     return sellOrders;
   }
 
-  public Order getOrderById(String uuid, String type){
-    if (type)
+  public Boolean removeOrder(String orderId, String orderType){
+
+    PriorityQueue<Order> targetQueue = (OrderType.valueOf(orderType) == OrderType.BUY) ? buyOrders : sellOrders;
+    Order orderToRemove=null;
+
+    for (Order order : targetQueue){
+      if (order.getId().toString().equals(orderId)){
+        orderToRemove = order;
+        break;
+      }
+    }
+
+    if (orderToRemove == null){
+      return false;
+    } else {
+      return targetQueue.remove(orderToRemove);
+    }
+      
   }
+    
 }

--- a/apps/OrderProcessor/src/test/java/orderProcessor/OrderProcessorTest.java
+++ b/apps/OrderProcessor/src/test/java/orderProcessor/OrderProcessorTest.java
@@ -24,7 +24,8 @@ class OrderProcessorTest {
     Order order = new Order(OrderType.SELL, Ticker.AAPL, 110.0, 50, "dummyID");
 
     orderProcessor.processOrder(order);
-    assertTrue(orderProcessor.cancelOrder(order));
+    Boolean result = orderProcessor.cancelOrder(order.getId().toString(), order.getTicker().name(), order.getType().name());
+    assertTrue(result);
   }
 
   @Test


### PR DESCRIPTION
The purpose of this MR is to fix a error i made while writing the cancelOrder() method in orderprocessor originally. That mistake was to write cancelOrder() to take an Order object as input, this was a bad move because when the API calls cancelOrder in the [/cancel-order](https://github.com/PerkinsDan/trading-platform/pull/22/files#diff-5e059f6fa77ec20d342393da5d07b519d53afe2687c69c56c6996aa8d28b1cb6R183) endpoint. 

In the current implementation, a new order is created and we call cancelOrder() on that new order, but this wont work as UUID is generated randomly on insantiation so the UUID of the order created by the endpoint wont match the UUID of hte order that  we are trying to cancel.

Solution : Change removeOrder() to take a String that represents the orderId, and use this to remove the order.
